### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ output on terminal emulators.
 The easiest way to install it is to use the [devtools] package.
 
 ```s
-library(devtools)
-install_github('jalvesaq/colorout')
+devtools::install_github("colorout", "jalvesaq")
 ```
 
 Released versions are available at


### PR DESCRIPTION
Devtools has been updated and `install_github('jalvesaq/colorout')` no longer works.
