### PR TITLE
Allow spaces in index - isindex

### DIFF
--- a/src/colorout.c
+++ b/src/colorout.c
@@ -100,14 +100,15 @@ static int isindex(const char * b, int i, int len)
 
     if(b[i] == ','){
         i++;
-        if(!(b[i] >= '0' && b[i] <= '9'))
+        if(!((b[i] >= '0' && b[i] <= '9') || b[i] == ' '))
             return 0;
     }
-    while(i < len && b[i] >= '0' && b[i] <= '9')
+    while(i < len && ((b[i] >= '0' && b[i] <= '9') || b[i] == ' '))
         i++;
 
     // Vector or matrix index?
-    if (b[i] == ']' || (b[i] == ',' && b[i+1] == ']'))
+    // Also check that the previous index is a digit
+    if ((b[i] == ']' && b[i-1] >= '0' && b[i-1] <= '9') || (b[i] == ',' && b[i+1] == ']' && b[i-1] >= '0' && b[i-1] <= '9'))
         return 1;
     else
         return 0;
@@ -340,7 +341,7 @@ void colorout_R_WriteConsoleEx (const char *buf, int len, int otype)
                 }
                 strcat(newbuf, crnormal);
                 j += normalsize;
-            } else if(bbuf[i] == '[' && ((bbuf[i+1] >= '0' && bbuf[i+1] <= '9') || bbuf[i+1] == ',') && isindex(bbuf, i+1, len)){
+            } else if(bbuf[i] == '[' && ((bbuf[i+1] >= '0' && bbuf[i+1] <= '9') || bbuf[i+1] == ',' || bbuf[i+1] == ' ') && isindex(bbuf, i+1, len)){
                 strcat(newbuf, crindex);
                 j += indexsize;
                 newbuf[j] = bbuf[i];


### PR DESCRIPTION
## Background
* Some packages and functions have output containing an index that aligns on the `[` and padding the inside with whitespace.
* If there is whitespace, `const int isindex` does not pick it up.
* This PR addresses that by: 
   - check for `' '` in addition for `.. >= '0' ... <= '9'`
   - check that there is at least one numeric character before the `']'` or before the `','` `']'`

## EXAMPLE of affected output:

```
      [ KEY ] ................. [ VALUE ]
[ 1,] a ............................... A
[ 2,] b ............................... B
[ 3,] c ............................... C
[ 4,] d ............................... D
[ 5,] e ............................... E
[ 6,] f ............................... F
[ 7,] g ............................... G
[ 8,] h ............................... H
[ 9,] i ............................... I
[10,] j ............................... J
[11,] k ............................... K
[12,] l ............................... L
[13,] m ............................... M
[14,] n ............................... N
[15,] o ............................... O
[16,] p ............................... P
```