### PR TITLE
Add function to check if colorout is enabled

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,7 +1,7 @@
 
 export("ColorOut", "noColorOut", "setOutputColors", "setOutputColors256",
        "show256Colors", "setZero", "unsetZero", "addPattern", "listPatterns",
-       "deletePattern")
+       "deletePattern", "isColorOut")
 
 importFrom("utils", "browseURL")
 

--- a/R/colorout.R
+++ b/R/colorout.R
@@ -79,6 +79,11 @@ noColorOut <- function()
     return (invisible(NULL))
 }
 
+isColorOut <- function()
+{
+    .Call("colorout_is_enabled", PACKAGE = "colorout")
+}
+
 GetColorCode <- function(x, name)
 {
     fname <- "setOutputColors: "

--- a/src/colorout.c
+++ b/src/colorout.c
@@ -812,3 +812,8 @@ void colorout_noColorOutput()
         colorout_initialized = 0;
     }
 }
+
+
+SEXP colorout_is_enabled() {
+  return ScalarLogical(colorout_initialized);
+}


### PR DESCRIPTION
I'm working on a package that uses non-standard escape codes for [terminal graphics](http://github.com/nfultz/osc1337) which colorout interferes with. 

I want to be able to check if colorout is enabled and temporarily switch it off, something like:

```r
    if(isColorOut()) {
      noColorOut()
      on.exit(ColorOut())
    }
```

This PR adds such a function in C, and an R wrapper.