### PR TITLE
Do not colorize output when package is loaded

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: colorout
-Version: 1.3-0.1
+Version: 1.3-0.2
 Date: 2023-09-26
 Title: Colorize R Output on Terminal Emulators
 Author: Jakson Aquino and Dominique-Laurent Couturier

--- a/R/colorout.R
+++ b/R/colorout.R
@@ -10,6 +10,8 @@
 
 
 .onLoad <- function(libname, pkgname) {
+    library.dynam("colorout", pkgname, libname, local = FALSE);
+
     if(is.null(getOption("colorout.anyterm")))
         options(colorout.anyterm = FALSE)
     if(is.null(getOption("colorout.dumb")))
@@ -20,13 +22,18 @@
         options(colorout.notatty = FALSE)
     if(is.null(getOption("colorout.verbose")))
         options(colorout.verbose = 0)
-    return(invisible(NULL))
+
+    msg <- testTermForColorOut()
+    if(msg != "OK" && getOption("colorout.verbose") > 0){
+        msg <- paste(gettext("The R output will not be colorized because it seems that your terminal does not support ANSI escape codes.", domain = "R-colorout"),
+                     msg)
+        warning(msg, call. = FALSE, immediate. = TRUE)
+    }
 }
 
 .onAttach <- function(libname, pkgname) {
     msg <- testTermForColorOut()
     if (msg == "OK") {
-        library.dynam("colorout", pkgname, libname, local = FALSE);
         ColorOut()
     } else if(getOption("colorout.verbose") > 0){
         msg <- paste(gettext("The R output will not be colorized because it seems that your terminal does not support ANSI escape codes.",
@@ -84,10 +91,7 @@ noColorOut <- function()
 
 isColorOut <- function()
 {
-    is_it <- try(.Call("colorout_is_enabled", PACKAGE = "colorout"), silent = TRUE)
-    if (inherits(is_it, "try-error"))
-        return(FALSE)
-    return(is_it)
+    .Call("colorout_is_enabled", PACKAGE = "colorout")
 }
 
 GetColorCode <- function(x, name)

--- a/tests/test-isColorOut.R
+++ b/tests/test-isColorOut.R
@@ -1,0 +1,19 @@
+if (requireNamespace("colorout", quietly = TRUE)) {
+    #options("colorout.verbose" = 2)
+
+    # ensure colorout is not attached
+    pkg <- "package:colorout"
+    if (pkg %in% search()) {
+        detach("package:colorout")
+    }
+
+    # isColorOut() should return FALSE if package is not attached
+    stopifnot(!colorout::isColorOut())
+
+    # isColorOut() should return TRUE if package is attached
+    if (interactive()) {
+        # colorout only works in interactive sessions
+        require("colorout", quietly = TRUE)
+        stopifnot(isColorOut())
+    }
+}


### PR DESCRIPTION
Output should only be colorized when the package is attached, not when it is loaded.This fixes #39.

Move the library load from `.onAttach()` to `.onLoad()` and remove the `ColorOut()` call from `.onLoad()` so loading does not start colorizing output.

Add a test to ensure that `colorout::isColorOut()` returns `FALSE` when the package is loaded but not attached.