### PR TITLE
docs(readme): add note about installing from r-multiverse

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,17 @@ Screenshot:
 
 ### Installation
 
-You can install the package by running the following commands in a terminal
+You can install the latest release version of the package from
+[R-multiverse](https://community.r-multiverse.org/):
+
+```r
+install.packages('colorout', repos = 'https://community.r-multiverse.org'))
+```
+
+You can install the development version by running the following commands in a terminal
 emulator:
 
-```
+```sh
 git clone https://github.com/jalvesaq/colorout.git
 R CMD INSTALL colorout
 ```

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You can install the latest release version of the package from
 [R-multiverse](https://community.r-multiverse.org/):
 
 ```r
-install.packages('colorout', repos = 'https://community.r-multiverse.org'))
+install.packages('colorout', repos = 'https://community.r-multiverse.org')
 ```
 
 You can install the development version by running the following commands in a terminal


### PR DESCRIPTION
A follow up for #42.

Releasing on R-multiverse seems working fine, so it might be worth mentioning in the README.