### PR TITLE
Fix typos

### DIFF
--- a/man/ColorOut.Rd
+++ b/man/ColorOut.Rd
@@ -3,7 +3,7 @@
 \title{Colorize R output in terminal emulator}
 \description{
   Colorize output of R running in a terminal emulator. The function is called
-  automatically when the package is loaded.
+  automatically when the package is attached.
 }
 \usage{
 ColorOut()

--- a/man/colorout-package.Rd
+++ b/man/colorout-package.Rd
@@ -39,7 +39,7 @@ Colorize R output on terminal emulators
   R should be built against libreadline since libedit may cause issues.
 
   The function that enables the colorization of R output is \link{ColorOut},
-  and it is called automatically when the package is loaded. However, it will
+  and it is called automatically when the package is attached. However, it will
   do nothing if \code{Sys.getenv("TERM")} returns either \code{""} or
   \code{"dumb"}. The output will not be colorized also if the result of either
   \code{interactive()} or \code{isatty(stdout())} is \code{FALSE}. You can


### PR DESCRIPTION
Strictly speaking, `colorout::ColorOut()` is called when the package is attached, rather than loaded.

https://github.com/jalvesaq/colorout/blob/15ff0be4a3fced8504c1d7ff1d05a64b32bab552/R/colorout.R#L34-L45